### PR TITLE
fix(controlplane): remove 2nd call to ctrl.SetupSignalHandler

### DIFF
--- a/controlplane/main.go
+++ b/controlplane/main.go
@@ -113,7 +113,7 @@ func main() {
 	// +kubebuilder:scaffold:builder
 
 	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}


### PR DESCRIPTION
Fixes panic on control plane controller start.

--------

* fix(controlplane): remove 2nd call to ctrl.SetupSignalHandler (7e5f05a)
