### PR TITLE
Bump up kube-rbac-proxy version to v0.16.0

### DIFF
--- a/bootstrap/config/default/manager_auth_proxy_patch.yaml
+++ b/bootstrap/config/default/manager_auth_proxy_patch.yaml
@@ -10,11 +10,10 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
-        - "--logtostderr=true"
         - "--v=10"
         ports:
         - containerPort: 8443

--- a/controlplane/config/default/manager_auth_proxy_patch.yaml
+++ b/controlplane/config/default/manager_auth_proxy_patch.yaml
@@ -10,11 +10,10 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
-        - "--logtostderr=true"
         - "--v=10"
         ports:
         - containerPort: 8443

--- a/samples/deployment/bootstrap-k3s/v1.2.2/bootstrap-components.yaml
+++ b/samples/deployment/bootstrap-k3s/v1.2.2/bootstrap-components.yaml
@@ -731,9 +731,8 @@ spec:
       - args:
         - --secure-listen-address=0.0.0.0:8443
         - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/samples/deployment/control-plane-k3s/v1.2.2/control-plane-components.yaml
+++ b/samples/deployment/control-plane-k3s/v1.2.2/control-plane-components.yaml
@@ -641,9 +641,8 @@ spec:
       - args:
         - --secure-listen-address=0.0.0.0:8443
         - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443


### PR DESCRIPTION
Note that `logtostderr` is deprecated, so I removed this flag.

Fixed #102 