### PR TITLE
Implement CustomValidator and CustomDefaulter webhook interfaces.

### DIFF
--- a/bootstrap/api/v1beta2/kthreesconfig_webhook.go
+++ b/bootstrap/api/v1beta2/kthreesconfig_webhook.go
@@ -28,11 +28,13 @@ import (
 func (c *KThreesConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(c).
+		WithDefaulter(&KThreesConfig{}).
+		WithValidator(&KThreesConfig{}).
 		Complete()
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/validate-controlplane-cluster-x-k8s-io-v1beta2-kthreesconfig,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=bootstrap.cluster.x-k8s.io,resources=kthreesconfig,versions=v1beta2,name=validation.kthreesconfig.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta2
-// +kubebuilder:webhook:verbs=create;update,path=/mutate-controlplane-cluster-x-k8s-io-v1beta2-kthreesconfig,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=bootstrap.cluster.x-k8s.io,resources=kthreesconfig,versions=v1beta2,name=default.kthreesconfig.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta2
+// +kubebuilder:webhook:verbs=create;update,path=/validate-bootstrap-cluster-x-k8s-io-v1beta2-kthreesconfig,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=bootstrap.cluster.x-k8s.io,resources=kthreesconfigs,versions=v1beta2,name=validation.kthreesconfig.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:verbs=create;update,path=/mutate-bootstrap-cluster-x-k8s-io-v1beta2-kthreesconfig,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=bootstrap.cluster.x-k8s.io,resources=kthreesconfigs,versions=v1beta2,name=default.kthreesconfig.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
 var _ admission.CustomDefaulter = &KThreesConfig{}
 var _ admission.CustomValidator = &KThreesConfig{}

--- a/bootstrap/api/v1beta2/kthreesconfig_webhook.go
+++ b/bootstrap/api/v1beta2/kthreesconfig_webhook.go
@@ -17,9 +17,10 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -33,24 +34,25 @@ func (c *KThreesConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:webhook:verbs=create;update,path=/validate-controlplane-cluster-x-k8s-io-v1beta2-kthreesconfig,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=bootstrap.cluster.x-k8s.io,resources=kthreesconfig,versions=v1beta2,name=validation.kthreesconfig.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta2
 // +kubebuilder:webhook:verbs=create;update,path=/mutate-controlplane-cluster-x-k8s-io-v1beta2-kthreesconfig,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=bootstrap.cluster.x-k8s.io,resources=kthreesconfig,versions=v1beta2,name=default.kthreesconfig.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta2
 
-var _ webhook.Defaulter = &KThreesConfig{}
-var _ webhook.Validator = &KThreesConfig{}
+var _ admission.CustomDefaulter = &KThreesConfig{}
+var _ admission.CustomValidator = &KThreesConfig{}
 
 // ValidateCreate will do any extra validation when creating a KThreesControlPlane.
-func (c *KThreesConfig) ValidateCreate() (admission.Warnings, error) {
+func (c *KThreesConfig) ValidateCreate(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return []string{}, nil
 }
 
 // ValidateUpdate will do any extra validation when updating a KThreesControlPlane.
-func (c *KThreesConfig) ValidateUpdate(runtime.Object) (admission.Warnings, error) {
+func (c *KThreesConfig) ValidateUpdate(_ context.Context, _, _ runtime.Object) (admission.Warnings, error) {
 	return []string{}, nil
 }
 
 // ValidateDelete allows you to add any extra validation when deleting.
-func (c *KThreesConfig) ValidateDelete() (admission.Warnings, error) {
+func (c *KThreesConfig) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return []string{}, nil
 }
 
 // Default will set default values for the KThreesControlPlane.
-func (c *KThreesConfig) Default() {
+func (c *KThreesConfig) Default(_ context.Context, _ runtime.Object) error {
+	return nil
 }

--- a/bootstrap/api/v1beta2/kthreesconfigtemplate_webhook.go
+++ b/bootstrap/api/v1beta2/kthreesconfigtemplate_webhook.go
@@ -28,11 +28,13 @@ import (
 func (c *KThreesConfigTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(c).
+		WithDefaulter(&KThreesConfigTemplate{}).
+		WithValidator(&KThreesConfigTemplate{}).
 		Complete()
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/validate-controlplane-cluster-x-k8s-io-v1beta2-kthreesconfigtemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=bootstrap.cluster.x-k8s.io,resources=kthreesconfigtemplate,versions=v1beta2,name=validation.kthreesconfigtemplate.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta2
-// +kubebuilder:webhook:verbs=create;update,path=/mutate-controlplane-cluster-x-k8s-io-v1beta2-kthreesconfigtemplate,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=bootstrap.cluster.x-k8s.io,resources=kthreesconfigtemplate,versions=v1beta2,name=default.kthreesconfigtemplate.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta2
+// +kubebuilder:webhook:verbs=create;update,path=/validate-bootstrap-cluster-x-k8s-io-v1beta2-kthreesconfigtemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=bootstrap.cluster.x-k8s.io,resources=kthreesconfigtemplates,versions=v1beta2,name=validation.kthreesconfigtemplate.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:verbs=create;update,path=/mutate-bootstrap-cluster-x-k8s-io-v1beta2-kthreesconfigtemplate,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=bootstrap.cluster.x-k8s.io,resources=kthreesconfigtemplates,versions=v1beta2,name=default.kthreesconfigtemplate.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
 var _ admission.CustomDefaulter = &KThreesConfigTemplate{}
 var _ admission.CustomValidator = &KThreesConfigTemplate{}

--- a/bootstrap/api/v1beta2/kthreesconfigtemplate_webhook.go
+++ b/bootstrap/api/v1beta2/kthreesconfigtemplate_webhook.go
@@ -17,9 +17,10 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -33,24 +34,25 @@ func (c *KThreesConfigTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error 
 // +kubebuilder:webhook:verbs=create;update,path=/validate-controlplane-cluster-x-k8s-io-v1beta2-kthreesconfigtemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=bootstrap.cluster.x-k8s.io,resources=kthreesconfigtemplate,versions=v1beta2,name=validation.kthreesconfigtemplate.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta2
 // +kubebuilder:webhook:verbs=create;update,path=/mutate-controlplane-cluster-x-k8s-io-v1beta2-kthreesconfigtemplate,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=bootstrap.cluster.x-k8s.io,resources=kthreesconfigtemplate,versions=v1beta2,name=default.kthreesconfigtemplate.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta2
 
-var _ webhook.Defaulter = &KThreesConfigTemplate{}
-var _ webhook.Validator = &KThreesConfigTemplate{}
+var _ admission.CustomDefaulter = &KThreesConfigTemplate{}
+var _ admission.CustomValidator = &KThreesConfigTemplate{}
 
 // ValidateCreate will do any extra validation when creating a KThreesControlPlane.
-func (c *KThreesConfigTemplate) ValidateCreate() (admission.Warnings, error) {
+func (c *KThreesConfigTemplate) ValidateCreate(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return []string{}, nil
 }
 
 // ValidateUpdate will do any extra validation when updating a KThreesControlPlane.
-func (c *KThreesConfigTemplate) ValidateUpdate(runtime.Object) (admission.Warnings, error) {
+func (c *KThreesConfigTemplate) ValidateUpdate(_ context.Context, _, _ runtime.Object) (admission.Warnings, error) {
 	return []string{}, nil
 }
 
 // ValidateDelete allows you to add any extra validation when deleting.
-func (c *KThreesConfigTemplate) ValidateDelete() (admission.Warnings, error) {
+func (c *KThreesConfigTemplate) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return []string{}, nil
 }
 
 // Default will set default values for the KThreesControlPlane.
-func (c *KThreesConfigTemplate) Default() {
+func (c *KThreesConfigTemplate) Default(_ context.Context, _ runtime.Object) error {
+	return nil
 }

--- a/bootstrap/config/webhook/manifests.yaml
+++ b/bootstrap/config/webhook/manifests.yaml
@@ -6,12 +6,12 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1
-  - v1beta2
+  - v1beta1
   clientConfig:
     service:
       name: webhook-service
       namespace: system
-      path: /mutate-controlplane-cluster-x-k8s-io-v1beta2-kthreesconfig
+      path: /mutate-bootstrap-cluster-x-k8s-io-v1beta2-kthreesconfig
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: default.kthreesconfig.bootstrap.cluster.x-k8s.io
@@ -24,16 +24,16 @@ webhooks:
     - CREATE
     - UPDATE
     resources:
-    - kthreesconfig
+    - kthreesconfigs
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  - v1beta2
+  - v1beta1
   clientConfig:
     service:
       name: webhook-service
       namespace: system
-      path: /mutate-controlplane-cluster-x-k8s-io-v1beta2-kthreesconfigtemplate
+      path: /mutate-bootstrap-cluster-x-k8s-io-v1beta2-kthreesconfigtemplate
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: default.kthreesconfigtemplate.bootstrap.cluster.x-k8s.io
@@ -46,7 +46,7 @@ webhooks:
     - CREATE
     - UPDATE
     resources:
-    - kthreesconfigtemplate
+    - kthreesconfigtemplates
   sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -56,12 +56,12 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1
-  - v1beta2
+  - v1beta1
   clientConfig:
     service:
       name: webhook-service
       namespace: system
-      path: /validate-controlplane-cluster-x-k8s-io-v1beta2-kthreesconfig
+      path: /validate-bootstrap-cluster-x-k8s-io-v1beta2-kthreesconfig
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: validation.kthreesconfig.bootstrap.cluster.x-k8s.io
@@ -74,16 +74,16 @@ webhooks:
     - CREATE
     - UPDATE
     resources:
-    - kthreesconfig
+    - kthreesconfigs
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  - v1beta2
+  - v1beta1
   clientConfig:
     service:
       name: webhook-service
       namespace: system
-      path: /validate-controlplane-cluster-x-k8s-io-v1beta2-kthreesconfigtemplate
+      path: /validate-bootstrap-cluster-x-k8s-io-v1beta2-kthreesconfigtemplate
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: validation.kthreesconfigtemplate.bootstrap.cluster.x-k8s.io
@@ -96,5 +96,5 @@ webhooks:
     - CREATE
     - UPDATE
     resources:
-    - kthreesconfigtemplate
+    - kthreesconfigtemplates
   sideEffects: None

--- a/controlplane/api/v1beta2/kthreescontrolplane_webhook.go
+++ b/controlplane/api/v1beta2/kthreescontrolplane_webhook.go
@@ -18,7 +18,9 @@ package v1beta2
 
 import (
 	"context"
+	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -28,11 +30,13 @@ import (
 func (in *KThreesControlPlane) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(in).
+		WithDefaulter(&KThreesControlPlane{}).
+		WithValidator(&KThreesControlPlane{}).
 		Complete()
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/validate-controlplane-cluster-x-k8s-io-v1beta2-kthreescontrolplane,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=controlplane.cluster.x-k8s.io,resources=kthreescontrolplane,versions=v1beta2,name=validation.kthreescontrolplane.controlplane.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta2
-// +kubebuilder:webhook:verbs=create;update,path=/mutate-controlplane-cluster-x-k8s-io-v1beta2-kthreescontrolplane,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=controlplane.cluster.x-k8s.io,resources=kthreescontrolplane,versions=v1beta2,name=default.kthreescontrolplane.controlplane.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta2
+// +kubebuilder:webhook:verbs=create;update,path=/validate-controlplane-cluster-x-k8s-io-v1beta2-kthreescontrolplane,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=controlplane.cluster.x-k8s.io,resources=kthreescontrolplanes,versions=v1beta2,name=validation.kthreescontrolplane.controlplane.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:verbs=create;update,path=/mutate-controlplane-cluster-x-k8s-io-v1beta2-kthreescontrolplane,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=controlplane.cluster.x-k8s.io,resources=kthreescontrolplanes,versions=v1beta2,name=default.kthreescontrolplane.controlplane.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
 var _ admission.CustomDefaulter = &KThreesControlPlane{}
 var _ admission.CustomValidator = &KThreesControlPlane{}
@@ -53,6 +57,23 @@ func (in *KThreesControlPlane) ValidateDelete(_ context.Context, _ runtime.Objec
 }
 
 // Default will set default values for the KThreesControlPlane.
-func (in *KThreesControlPlane) Default(_ context.Context, _ runtime.Object) error {
+func (in *KThreesControlPlane) Default(_ context.Context, obj runtime.Object) error {
+	c, ok := obj.(*KThreesControlPlane)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a KubeadmConfig but got a %T", obj))
+	}
+
+	defaultKThreesControlPlaneSpec(&c.Spec, c.Namespace)
 	return nil
+}
+
+func defaultKThreesControlPlaneSpec(s *KThreesControlPlaneSpec, namespace string) {
+	if s.Replicas == nil {
+		replicas := int32(1)
+		s.Replicas = &replicas
+	}
+
+	if s.MachineTemplate.InfrastructureRef.Namespace == "" {
+		s.MachineTemplate.InfrastructureRef.Namespace = namespace
+	}
 }

--- a/controlplane/api/v1beta2/kthreescontrolplane_webhook.go
+++ b/controlplane/api/v1beta2/kthreescontrolplane_webhook.go
@@ -17,9 +17,10 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -33,24 +34,25 @@ func (in *KThreesControlPlane) SetupWebhookWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:webhook:verbs=create;update,path=/validate-controlplane-cluster-x-k8s-io-v1beta2-kthreescontrolplane,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=controlplane.cluster.x-k8s.io,resources=kthreescontrolplane,versions=v1beta2,name=validation.kthreescontrolplane.controlplane.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta2
 // +kubebuilder:webhook:verbs=create;update,path=/mutate-controlplane-cluster-x-k8s-io-v1beta2-kthreescontrolplane,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=controlplane.cluster.x-k8s.io,resources=kthreescontrolplane,versions=v1beta2,name=default.kthreescontrolplane.controlplane.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta2
 
-var _ webhook.Defaulter = &KThreesControlPlane{}
-var _ webhook.Validator = &KThreesControlPlane{}
+var _ admission.CustomDefaulter = &KThreesControlPlane{}
+var _ admission.CustomValidator = &KThreesControlPlane{}
 
 // ValidateCreate will do any extra validation when creating a KThreesControlPlane.
-func (in *KThreesControlPlane) ValidateCreate() (admission.Warnings, error) {
+func (in *KThreesControlPlane) ValidateCreate(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return []string{}, nil
 }
 
 // ValidateUpdate will do any extra validation when updating a KThreesControlPlane.
-func (in *KThreesControlPlane) ValidateUpdate(runtime.Object) (admission.Warnings, error) {
+func (in *KThreesControlPlane) ValidateUpdate(_ context.Context, _, _ runtime.Object) (admission.Warnings, error) {
 	return []string{}, nil
 }
 
 // ValidateDelete allows you to add any extra validation when deleting.
-func (in *KThreesControlPlane) ValidateDelete() (admission.Warnings, error) {
+func (in *KThreesControlPlane) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return []string{}, nil
 }
 
 // Default will set default values for the KThreesControlPlane.
-func (in *KThreesControlPlane) Default() {
+func (in *KThreesControlPlane) Default(_ context.Context, _ runtime.Object) error {
+	return nil
 }

--- a/controlplane/config/webhook/manifests.yaml
+++ b/controlplane/config/webhook/manifests.yaml
@@ -6,7 +6,7 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1
-  - v1beta2
+  - v1beta1
   clientConfig:
     service:
       name: webhook-service
@@ -24,7 +24,7 @@ webhooks:
     - CREATE
     - UPDATE
     resources:
-    - kthreescontrolplane
+    - kthreescontrolplanes
   sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -34,7 +34,7 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1
-  - v1beta2
+  - v1beta1
   clientConfig:
     service:
       name: webhook-service
@@ -52,5 +52,5 @@ webhooks:
     - CREATE
     - UPDATE
     resources:
-    - kthreescontrolplane
+    - kthreescontrolplanes
   sideEffects: None


### PR DESCRIPTION
This PR should hopefully address https://github.com/k3s-io/cluster-api-k3s/issues/110

The webhook.Defaulter and webhook.Validator interfaces are deprecated anyway, so they should be updated.