### PR TITLE
Deprecate DisableExternalCloudProvider

### DIFF
--- a/bootstrap/api/v1beta1/conversion.go
+++ b/bootstrap/api/v1beta1/conversion.go
@@ -16,32 +16,50 @@ package v1beta1
 import (
 	"fmt"
 
-	"sigs.k8s.io/controller-runtime/pkg/conversion"
+	"k8s.io/apimachinery/pkg/conversion"
+	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
+	ctrlconversion "sigs.k8s.io/controller-runtime/pkg/conversion"
 
-	cabp3v1 "github.com/k3s-io/cluster-api-k3s/bootstrap/api/v1beta2"
+	bootstrapv1beta2 "github.com/k3s-io/cluster-api-k3s/bootstrap/api/v1beta2"
 )
 
 // ConvertTo converts the v1beta1 KThreesConfig receiver to a v1beta2 KThreesConfig.
-func (c *KThreesConfig) ConvertTo(dstRaw conversion.Hub) error {
-	dst := dstRaw.(*cabp3v1.KThreesConfig)
-	if err := autoConvert_v1beta1_KThreesConfig_To_v1beta2_KThreesConfig(c, dst, nil); err != nil {
+func (c *KThreesConfig) ConvertTo(dstRaw ctrlconversion.Hub) error {
+	dst := dstRaw.(*bootstrapv1beta2.KThreesConfig)
+	if err := Convert_v1beta1_KThreesConfig_To_v1beta2_KThreesConfig(c, dst, nil); err != nil {
 		return fmt.Errorf("converting KThreesConfig v1beta1 to v1beta2: %w", err)
 	}
+
+	restored := &bootstrapv1beta2.KThreesConfig{}
+	if ok, err := utilconversion.UnmarshalData(c, restored); err != nil {
+		return fmt.Errorf("unmarshalling stored conversion data: %w", err)
+	} else if !ok {
+		// No stored data.
+		return nil
+	}
+
+	dst.Spec.ServerConfig.CloudProviderName = restored.Spec.ServerConfig.CloudProviderName
+	dst.Spec.ServerConfig.DeprecatedDisableExternalCloudProvider = restored.Spec.ServerConfig.DeprecatedDisableExternalCloudProvider
+	dst.Spec.ServerConfig.DisableCloudController = restored.Spec.ServerConfig.DisableCloudController
 	return nil
 }
 
 // ConvertFrom converts the v1beta1 KThreesConfig receiver from a v1beta2 KThreesConfig.
-func (c *KThreesConfig) ConvertFrom(srcRaw conversion.Hub) error {
-	src := srcRaw.(*cabp3v1.KThreesConfig)
-	if err := autoConvert_v1beta2_KThreesConfig_To_v1beta1_KThreesConfig(src, c, nil); err != nil {
+func (c *KThreesConfig) ConvertFrom(srcRaw ctrlconversion.Hub) error {
+	src := srcRaw.(*bootstrapv1beta2.KThreesConfig)
+	if err := Convert_v1beta2_KThreesConfig_To_v1beta1_KThreesConfig(src, c, nil); err != nil {
 		return fmt.Errorf("converting KThreesConfig v1beta1 from v1beta2: %w", err)
+	}
+
+	if err := utilconversion.MarshalData(src, c); err != nil {
+		return fmt.Errorf("storing conversion data: %w", err)
 	}
 	return nil
 }
 
 // ConvertTo converts the v1beta1 KThreesConfigList receiver to a v1beta2 KThreesConfigList.
-func (c *KThreesConfigList) ConvertTo(dstRaw conversion.Hub) error {
-	dst := dstRaw.(*cabp3v1.KThreesConfigList)
+func (c *KThreesConfigList) ConvertTo(dstRaw ctrlconversion.Hub) error {
+	dst := dstRaw.(*bootstrapv1beta2.KThreesConfigList)
 	if err := autoConvert_v1beta1_KThreesConfigList_To_v1beta2_KThreesConfigList(c, dst, nil); err != nil {
 		return fmt.Errorf("converting KThreesConfigList v1beta1 to v1beta2: %w", err)
 	}
@@ -49,8 +67,8 @@ func (c *KThreesConfigList) ConvertTo(dstRaw conversion.Hub) error {
 }
 
 // ConvertFrom converts the v1beta1 KThreesConfigList receiver from a v1beta2 KThreesConfigList.
-func (c *KThreesConfigList) ConvertFrom(srcRaw conversion.Hub) error {
-	src := srcRaw.(*cabp3v1.KThreesConfigList)
+func (c *KThreesConfigList) ConvertFrom(srcRaw ctrlconversion.Hub) error {
+	src := srcRaw.(*bootstrapv1beta2.KThreesConfigList)
 	if err := autoConvert_v1beta2_KThreesConfigList_To_v1beta1_KThreesConfigList(src, c, nil); err != nil {
 		return fmt.Errorf("converting KThreesConfigList v1beta1 from v1beta2: %w", err)
 	}
@@ -58,26 +76,42 @@ func (c *KThreesConfigList) ConvertFrom(srcRaw conversion.Hub) error {
 }
 
 // ConvertTo converts the v1beta1 KThreesConfigTemplate receiver to a v1beta2 KThreesConfigTemplate.
-func (r *KThreesConfigTemplate) ConvertTo(dstRaw conversion.Hub) error {
-	dst := dstRaw.(*cabp3v1.KThreesConfigTemplate)
+func (r *KThreesConfigTemplate) ConvertTo(dstRaw ctrlconversion.Hub) error {
+	dst := dstRaw.(*bootstrapv1beta2.KThreesConfigTemplate)
 	if err := autoConvert_v1beta1_KThreesConfigTemplate_To_v1beta2_KThreesConfigTemplate(r, dst, nil); err != nil {
 		return fmt.Errorf("converting KThreesConfigTemplate v1beta1 to v1beta2: %w", err)
 	}
+
+	restored := &bootstrapv1beta2.KThreesConfigTemplate{}
+	if ok, err := utilconversion.UnmarshalData(r, restored); err != nil {
+		return fmt.Errorf("unmarshalling stored conversion data: %w", err)
+	} else if !ok {
+		// No stored data.
+		return nil
+	}
+
+	dst.Spec.Template.Spec.ServerConfig.CloudProviderName = restored.Spec.Template.Spec.ServerConfig.CloudProviderName
+	dst.Spec.Template.Spec.ServerConfig.DeprecatedDisableExternalCloudProvider = restored.Spec.Template.Spec.ServerConfig.DeprecatedDisableExternalCloudProvider
+	dst.Spec.Template.Spec.ServerConfig.DisableCloudController = restored.Spec.Template.Spec.ServerConfig.DisableCloudController
 	return nil
 }
 
 // ConvertFrom converts the v1beta1 KThreesConfigTemplate receiver from a v1beta2 KThreesConfigTemplate.
-func (r *KThreesConfigTemplate) ConvertFrom(srcRaw conversion.Hub) error {
-	src := srcRaw.(*cabp3v1.KThreesConfigTemplate)
+func (r *KThreesConfigTemplate) ConvertFrom(srcRaw ctrlconversion.Hub) error {
+	src := srcRaw.(*bootstrapv1beta2.KThreesConfigTemplate)
 	if err := autoConvert_v1beta2_KThreesConfigTemplate_To_v1beta1_KThreesConfigTemplate(src, r, nil); err != nil {
 		return fmt.Errorf("converting KThreesConfigTemplate v1beta1 from v1beta2: %w", err)
+	}
+
+	if err := utilconversion.MarshalData(src, r); err != nil {
+		return fmt.Errorf("storing conversion data: %w", err)
 	}
 	return nil
 }
 
 // ConvertTo converts the v1beta1 KThreesConfigTemplateList receiver to a v1beta2 KThreesConfigTemplateList.
-func (r *KThreesConfigTemplateList) ConvertTo(dstRaw conversion.Hub) error {
-	dst := dstRaw.(*cabp3v1.KThreesConfigTemplateList)
+func (r *KThreesConfigTemplateList) ConvertTo(dstRaw ctrlconversion.Hub) error {
+	dst := dstRaw.(*bootstrapv1beta2.KThreesConfigTemplateList)
 	if err := autoConvert_v1beta1_KThreesConfigTemplateList_To_v1beta2_KThreesConfigTemplateList(r, dst, nil); err != nil {
 		return fmt.Errorf("converting KThreesConfigTemplateList v1beta1 to v1beta2: %w", err)
 	}
@@ -85,10 +119,40 @@ func (r *KThreesConfigTemplateList) ConvertTo(dstRaw conversion.Hub) error {
 }
 
 // ConvertFrom converts the v1beta1 KThreesConfigTemplateList receiver from a v1beta2 KThreesConfigTemplateList.
-func (r *KThreesConfigTemplateList) ConvertFrom(srcRaw conversion.Hub) error {
-	src := srcRaw.(*cabp3v1.KThreesConfigTemplateList)
+func (r *KThreesConfigTemplateList) ConvertFrom(srcRaw ctrlconversion.Hub) error {
+	src := srcRaw.(*bootstrapv1beta2.KThreesConfigTemplateList)
 	if err := autoConvert_v1beta2_KThreesConfigTemplateList_To_v1beta1_KThreesConfigTemplateList(src, r, nil); err != nil {
 		return fmt.Errorf("converting KThreesConfigTemplateList v1beta1 from v1beta2: %w", err)
 	}
+	return nil
+}
+
+// Convert_v1beta1_KThreesServerConfig_To_v1beta2_KThreesServerConfig converts KThreesServerConfig v1beta1 to v1beta2.
+func Convert_v1beta1_KThreesServerConfig_To_v1beta2_KThreesServerConfig(in *KThreesServerConfig, out *bootstrapv1beta2.KThreesServerConfig, s conversion.Scope) error { //nolint: stylecheck
+	if err := autoConvert_v1beta1_KThreesServerConfig_To_v1beta2_KThreesServerConfig(in, out, s); err != nil {
+		return fmt.Errorf("converting KThreesServerConfig v1beta1 to v1beta2: %w", err)
+	}
+
+	out.DeprecatedDisableExternalCloudProvider = in.DisableExternalCloudProvider
+
+	if !in.DisableExternalCloudProvider {
+		out.CloudProviderName = "external"
+		out.DisableCloudController = true
+	} else {
+		out.CloudProviderName = ""
+		out.DisableCloudController = false
+	}
+
+	return nil
+}
+
+// Convert_v1beta2_KThreesServerConfig_To_v1beta1_KThreesServerConfig converts KThreesServerConfig v1beta2 to v1beta1.
+func Convert_v1beta2_KThreesServerConfig_To_v1beta1_KThreesServerConfig(in *bootstrapv1beta2.KThreesServerConfig, out *KThreesServerConfig, s conversion.Scope) error { //nolint: stylecheck
+	if err := autoConvert_v1beta2_KThreesServerConfig_To_v1beta1_KThreesServerConfig(in, out, s); err != nil {
+		return fmt.Errorf("converting KThreesServerConfig v1beta2 to v1beta1: %w", err)
+	}
+
+	out.DisableExternalCloudProvider = in.DeprecatedDisableExternalCloudProvider
+
 	return nil
 }

--- a/bootstrap/api/v1beta1/conversion_test.go
+++ b/bootstrap/api/v1beta1/conversion_test.go
@@ -21,24 +21,24 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 
-	cabp3v1 "github.com/k3s-io/cluster-api-k3s/bootstrap/api/v1beta2"
+	bootstrapv1beta2 "github.com/k3s-io/cluster-api-k3s/bootstrap/api/v1beta2"
 )
 
 func TestFuzzyConversion(t *testing.T) {
 	g := NewWithT(t)
 	scheme := runtime.NewScheme()
 	g.Expect(AddToScheme(scheme)).To(Succeed())
-	g.Expect(cabp3v1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(bootstrapv1beta2.AddToScheme(scheme)).To(Succeed())
 
 	t.Run("for KThreesConfig", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
 		Scheme:      scheme,
-		Hub:         &cabp3v1.KThreesConfig{},
+		Hub:         &bootstrapv1beta2.KThreesConfig{},
 		Spoke:       &KThreesConfig{},
 		FuzzerFuncs: []fuzzer.FuzzerFuncs{},
 	}))
 	t.Run("for KThreesConfigTemplate", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
 		Scheme:      scheme,
-		Hub:         &cabp3v1.KThreesConfigTemplate{},
+		Hub:         &bootstrapv1beta2.KThreesConfigTemplate{},
 		Spoke:       &KThreesConfigTemplate{},
 		FuzzerFuncs: []fuzzer.FuzzerFuncs{},
 	}))

--- a/bootstrap/api/v1beta1/zz_generated.conversion.go
+++ b/bootstrap/api/v1beta1/zz_generated.conversion.go
@@ -146,16 +146,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*KThreesServerConfig)(nil), (*v1beta2.KThreesServerConfig)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta1_KThreesServerConfig_To_v1beta2_KThreesServerConfig(a.(*KThreesServerConfig), b.(*v1beta2.KThreesServerConfig), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*v1beta2.KThreesServerConfig)(nil), (*KThreesServerConfig)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta2_KThreesServerConfig_To_v1beta1_KThreesServerConfig(a.(*v1beta2.KThreesServerConfig), b.(*KThreesServerConfig), scope)
-	}); err != nil {
-		return err
-	}
 	if err := s.AddGeneratedConversionFunc((*SecretFileSource)(nil), (*v1beta2.SecretFileSource)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta1_SecretFileSource_To_v1beta2_SecretFileSource(a.(*SecretFileSource), b.(*v1beta2.SecretFileSource), scope)
 	}); err != nil {
@@ -163,6 +153,16 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}
 	if err := s.AddGeneratedConversionFunc((*v1beta2.SecretFileSource)(nil), (*SecretFileSource)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta2_SecretFileSource_To_v1beta1_SecretFileSource(a.(*v1beta2.SecretFileSource), b.(*SecretFileSource), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*KThreesServerConfig)(nil), (*v1beta2.KThreesServerConfig)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta1_KThreesServerConfig_To_v1beta2_KThreesServerConfig(a.(*KThreesServerConfig), b.(*v1beta2.KThreesServerConfig), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*v1beta2.KThreesServerConfig)(nil), (*KThreesServerConfig)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta2_KThreesServerConfig_To_v1beta1_KThreesServerConfig(a.(*v1beta2.KThreesServerConfig), b.(*KThreesServerConfig), scope)
 	}); err != nil {
 		return err
 	}
@@ -289,7 +289,17 @@ func Convert_v1beta2_KThreesConfig_To_v1beta1_KThreesConfig(in *v1beta2.KThreesC
 
 func autoConvert_v1beta1_KThreesConfigList_To_v1beta2_KThreesConfigList(in *KThreesConfigList, out *v1beta2.KThreesConfigList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]v1beta2.KThreesConfig)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]v1beta2.KThreesConfig, len(*in))
+		for i := range *in {
+			if err := Convert_v1beta1_KThreesConfig_To_v1beta2_KThreesConfig(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -300,7 +310,17 @@ func Convert_v1beta1_KThreesConfigList_To_v1beta2_KThreesConfigList(in *KThreesC
 
 func autoConvert_v1beta2_KThreesConfigList_To_v1beta1_KThreesConfigList(in *v1beta2.KThreesConfigList, out *KThreesConfigList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]KThreesConfig)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]KThreesConfig, len(*in))
+		for i := range *in {
+			if err := Convert_v1beta2_KThreesConfig_To_v1beta1_KThreesConfig(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -407,7 +427,17 @@ func Convert_v1beta2_KThreesConfigTemplate_To_v1beta1_KThreesConfigTemplate(in *
 
 func autoConvert_v1beta1_KThreesConfigTemplateList_To_v1beta2_KThreesConfigTemplateList(in *KThreesConfigTemplateList, out *v1beta2.KThreesConfigTemplateList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]v1beta2.KThreesConfigTemplate)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]v1beta2.KThreesConfigTemplate, len(*in))
+		for i := range *in {
+			if err := Convert_v1beta1_KThreesConfigTemplate_To_v1beta2_KThreesConfigTemplate(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -418,7 +448,17 @@ func Convert_v1beta1_KThreesConfigTemplateList_To_v1beta2_KThreesConfigTemplateL
 
 func autoConvert_v1beta2_KThreesConfigTemplateList_To_v1beta1_KThreesConfigTemplateList(in *v1beta2.KThreesConfigTemplateList, out *KThreesConfigTemplateList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]KThreesConfigTemplate)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]KThreesConfigTemplate, len(*in))
+		for i := range *in {
+			if err := Convert_v1beta2_KThreesConfigTemplate_To_v1beta1_KThreesConfigTemplate(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -489,13 +529,8 @@ func autoConvert_v1beta1_KThreesServerConfig_To_v1beta2_KThreesServerConfig(in *
 	out.ClusterDNS = in.ClusterDNS
 	out.ClusterDomain = in.ClusterDomain
 	out.DisableComponents = *(*[]string)(unsafe.Pointer(&in.DisableComponents))
-	out.DisableExternalCloudProvider = in.DisableExternalCloudProvider
+	// WARNING: in.DisableExternalCloudProvider requires manual conversion: does not exist in peer-type
 	return nil
-}
-
-// Convert_v1beta1_KThreesServerConfig_To_v1beta2_KThreesServerConfig is an autogenerated conversion function.
-func Convert_v1beta1_KThreesServerConfig_To_v1beta2_KThreesServerConfig(in *KThreesServerConfig, out *v1beta2.KThreesServerConfig, s conversion.Scope) error {
-	return autoConvert_v1beta1_KThreesServerConfig_To_v1beta2_KThreesServerConfig(in, out, s)
 }
 
 func autoConvert_v1beta2_KThreesServerConfig_To_v1beta1_KThreesServerConfig(in *v1beta2.KThreesServerConfig, out *KThreesServerConfig, s conversion.Scope) error {
@@ -512,13 +547,10 @@ func autoConvert_v1beta2_KThreesServerConfig_To_v1beta1_KThreesServerConfig(in *
 	out.ClusterDNS = in.ClusterDNS
 	out.ClusterDomain = in.ClusterDomain
 	out.DisableComponents = *(*[]string)(unsafe.Pointer(&in.DisableComponents))
-	out.DisableExternalCloudProvider = in.DisableExternalCloudProvider
+	// WARNING: in.DeprecatedDisableExternalCloudProvider requires manual conversion: does not exist in peer-type
+	// WARNING: in.DisableCloudController requires manual conversion: does not exist in peer-type
+	// WARNING: in.CloudProviderName requires manual conversion: does not exist in peer-type
 	return nil
-}
-
-// Convert_v1beta2_KThreesServerConfig_To_v1beta1_KThreesServerConfig is an autogenerated conversion function.
-func Convert_v1beta2_KThreesServerConfig_To_v1beta1_KThreesServerConfig(in *v1beta2.KThreesServerConfig, out *KThreesServerConfig, s conversion.Scope) error {
-	return autoConvert_v1beta2_KThreesServerConfig_To_v1beta1_KThreesServerConfig(in, out, s)
 }
 
 func autoConvert_v1beta1_SecretFileSource_To_v1beta2_SecretFileSource(in *SecretFileSource, out *v1beta2.SecretFileSource, s conversion.Scope) error {

--- a/bootstrap/api/v1beta2/kthreesconfig_types.go
+++ b/bootstrap/api/v1beta2/kthreesconfig_types.go
@@ -109,9 +109,19 @@ type KThreesServerConfig struct {
 	// +optional
 	DisableComponents []string `json:"disableComponents,omitempty"`
 
-	// DisableExternalCloudProvider suppresses the 'cloud-provider=external' kubelet argument. (default: false)
+	// DeprecatedDisableExternalCloudProvider suppresses the 'cloud-provider=external' kubelet argument. (default: false)
 	// +optional
-	DisableExternalCloudProvider bool `json:"disableExternalCloudProvider,omitempty"`
+	DeprecatedDisableExternalCloudProvider bool `json:"disableExternalCloudProvider,omitempty"`
+
+	// DisableCloudController disables k3s default cloud controller manager. (default: true)
+	// +optional
+	// +kubebuilder:default=true
+	DisableCloudController bool `json:"disableCloudController,omitempty"`
+
+	// CloudProviderName defines the --cloud-provider= kubelet extra arg. (default: "external")
+	// +optional
+	// +kubebuilder:default=external
+	CloudProviderName string `json:"cloudProviderName,omitempty"`
 }
 
 type KThreesAgentConfig struct {

--- a/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_kthreesconfigs.yaml
+++ b/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_kthreesconfigs.yaml
@@ -441,6 +441,11 @@ spec:
                   bindAddress:
                     description: 'BindAddress k3s bind address (default: 0.0.0.0)'
                     type: string
+                  cloudProviderName:
+                    default: external
+                    description: 'CloudProviderName defines the --cloud-provider=
+                      kubelet extra arg. (default: "external")'
+                    type: string
                   clusterCidr:
                     description: 'ClusterCidr  Network CIDR to use for pod IPs (default:
                       "10.42.0.0/16")'
@@ -452,6 +457,11 @@ spec:
                   clusterDomain:
                     description: 'ClusterDomain Cluster Domain (default: "cluster.local")'
                     type: string
+                  disableCloudController:
+                    default: true
+                    description: 'DisableCloudController disables k3s default cloud
+                      controller manager. (default: true)'
+                    type: boolean
                   disableComponents:
                     description: DisableComponents  specifies extra commands to run
                       before k3s setup runs
@@ -459,8 +469,9 @@ spec:
                       type: string
                     type: array
                   disableExternalCloudProvider:
-                    description: 'DisableExternalCloudProvider suppresses the ''cloud-provider=external''
-                      kubelet argument. (default: false)'
+                    description: 'DeprecatedDisableExternalCloudProvider suppresses
+                      the ''cloud-provider=external'' kubelet argument. (default:
+                      false)'
                     type: boolean
                   httpsListenPort:
                     description: 'HTTPSListenPort HTTPS listen port (default: 6443)'

--- a/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_kthreesconfigtemplates.yaml
+++ b/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_kthreesconfigtemplates.yaml
@@ -402,6 +402,11 @@ spec:
                           bindAddress:
                             description: 'BindAddress k3s bind address (default: 0.0.0.0)'
                             type: string
+                          cloudProviderName:
+                            default: external
+                            description: 'CloudProviderName defines the --cloud-provider=
+                              kubelet extra arg. (default: "external")'
+                            type: string
                           clusterCidr:
                             description: 'ClusterCidr  Network CIDR to use for pod
                               IPs (default: "10.42.0.0/16")'
@@ -413,6 +418,11 @@ spec:
                           clusterDomain:
                             description: 'ClusterDomain Cluster Domain (default: "cluster.local")'
                             type: string
+                          disableCloudController:
+                            default: true
+                            description: 'DisableCloudController disables k3s default
+                              cloud controller manager. (default: true)'
+                            type: boolean
                           disableComponents:
                             description: DisableComponents  specifies extra commands
                               to run before k3s setup runs
@@ -420,7 +430,7 @@ spec:
                               type: string
                             type: array
                           disableExternalCloudProvider:
-                            description: 'DisableExternalCloudProvider suppresses
+                            description: 'DeprecatedDisableExternalCloudProvider suppresses
                               the ''cloud-provider=external'' kubelet argument. (default:
                               false)'
                             type: boolean

--- a/controlplane/api/v1beta1/conversion_test.go
+++ b/controlplane/api/v1beta1/conversion_test.go
@@ -21,18 +21,18 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 
-	cabp3v1 "github.com/k3s-io/cluster-api-k3s/controlplane/api/v1beta2"
+	bootstrapv1beta2 "github.com/k3s-io/cluster-api-k3s/controlplane/api/v1beta2"
 )
 
 func TestFuzzyConversion(t *testing.T) {
 	g := NewWithT(t)
 	scheme := runtime.NewScheme()
 	g.Expect(AddToScheme(scheme)).To(Succeed())
-	g.Expect(cabp3v1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(bootstrapv1beta2.AddToScheme(scheme)).To(Succeed())
 
 	t.Run("for KThreesControlPlane", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
 		Scheme:      scheme,
-		Hub:         &cabp3v1.KThreesControlPlane{},
+		Hub:         &bootstrapv1beta2.KThreesControlPlane{},
 		Spoke:       &KThreesControlPlane{},
 		FuzzerFuncs: []fuzzer.FuzzerFuncs{},
 	}))

--- a/controlplane/api/v1beta1/kthreescontrolplane_types.go
+++ b/controlplane/api/v1beta1/kthreescontrolplane_types.go
@@ -23,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
-	cabp3v1 "github.com/k3s-io/cluster-api-k3s/bootstrap/api/v1beta1"
+	bootstrapv1beta1 "github.com/k3s-io/cluster-api-k3s/bootstrap/api/v1beta1"
 	"github.com/k3s-io/cluster-api-k3s/pkg/errors"
 )
 
@@ -76,7 +76,7 @@ type KThreesControlPlaneSpec struct {
 	// KThreesConfigSpec is a KThreesConfigSpec
 	// to use for initializing and joining machines to the control plane.
 	// +optional
-	KThreesConfigSpec cabp3v1.KThreesConfigSpec `json:"kthreesConfigSpec,omitempty"`
+	KThreesConfigSpec bootstrapv1beta1.KThreesConfigSpec `json:"kthreesConfigSpec,omitempty"`
 
 	// UpgradeAfter is a field to indicate an upgrade should be performed
 	// after the specified time even if no changes have been made to the

--- a/controlplane/api/v1beta2/kthreescontrolplane_types.go
+++ b/controlplane/api/v1beta2/kthreescontrolplane_types.go
@@ -23,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
-	cabp3v1 "github.com/k3s-io/cluster-api-k3s/bootstrap/api/v1beta2"
+	bootstrapv1beta2 "github.com/k3s-io/cluster-api-k3s/bootstrap/api/v1beta2"
 	"github.com/k3s-io/cluster-api-k3s/pkg/errors"
 )
 
@@ -69,7 +69,7 @@ type KThreesControlPlaneSpec struct {
 	// KThreesConfigSpec is a KThreesConfigSpec
 	// to use for initializing and joining machines to the control plane.
 	// +optional
-	KThreesConfigSpec cabp3v1.KThreesConfigSpec `json:"kthreesConfigSpec,omitempty"`
+	KThreesConfigSpec bootstrapv1beta2.KThreesConfigSpec `json:"kthreesConfigSpec,omitempty"`
 
 	// UpgradeAfter is a field to indicate an upgrade should be performed
 	// after the specified time even if no changes have been made to the

--- a/controlplane/api/v1beta2/kthreescontrolplanetemplate_types.go
+++ b/controlplane/api/v1beta2/kthreescontrolplanetemplate_types.go
@@ -19,7 +19,7 @@ package v1beta2
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	cabp3v1 "github.com/k3s-io/cluster-api-k3s/bootstrap/api/v1beta2"
+	bootstrapv1beta2 "github.com/k3s-io/cluster-api-k3s/bootstrap/api/v1beta2"
 )
 
 // KThreesControlPlaneTemplateSpec defines the desired state of KThreesControlPlaneTemplateSpec.
@@ -39,7 +39,7 @@ type KThreesControlPlaneTemplateResourceSpec struct {
 	// KThreesConfigSpec is a KThreesConfigSpec
 	// to use for initializing and joining machines to the control plane.
 	// +optional
-	KThreesConfigSpec cabp3v1.KThreesConfigSpec `json:"kthreesConfigSpec,omitempty"`
+	KThreesConfigSpec bootstrapv1beta2.KThreesConfigSpec `json:"kthreesConfigSpec,omitempty"`
 
 	// UpgradeAfter is a field to indicate an upgrade should be performed
 	// after the specified time even if no changes have been made to the

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_kthreescontrolplanes.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_kthreescontrolplanes.yaml
@@ -748,6 +748,11 @@ spec:
                       bindAddress:
                         description: 'BindAddress k3s bind address (default: 0.0.0.0)'
                         type: string
+                      cloudProviderName:
+                        default: external
+                        description: 'CloudProviderName defines the --cloud-provider=
+                          kubelet extra arg. (default: "external")'
+                        type: string
                       clusterCidr:
                         description: 'ClusterCidr  Network CIDR to use for pod IPs
                           (default: "10.42.0.0/16")'
@@ -759,6 +764,11 @@ spec:
                       clusterDomain:
                         description: 'ClusterDomain Cluster Domain (default: "cluster.local")'
                         type: string
+                      disableCloudController:
+                        default: true
+                        description: 'DisableCloudController disables k3s default
+                          cloud controller manager. (default: true)'
+                        type: boolean
                       disableComponents:
                         description: DisableComponents  specifies extra commands to
                           run before k3s setup runs
@@ -766,8 +776,8 @@ spec:
                           type: string
                         type: array
                       disableExternalCloudProvider:
-                        description: 'DisableExternalCloudProvider suppresses the
-                          ''cloud-provider=external'' kubelet argument. (default:
+                        description: 'DeprecatedDisableExternalCloudProvider suppresses
+                          the ''cloud-provider=external'' kubelet argument. (default:
                           false)'
                         type: boolean
                       httpsListenPort:

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_kthreescontrolplanetemplates.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_kthreescontrolplanetemplates.yaml
@@ -187,6 +187,11 @@ spec:
                                 description: 'BindAddress k3s bind address (default:
                                   0.0.0.0)'
                                 type: string
+                              cloudProviderName:
+                                default: external
+                                description: 'CloudProviderName defines the --cloud-provider=
+                                  kubelet extra arg. (default: "external")'
+                                type: string
                               clusterCidr:
                                 description: 'ClusterCidr  Network CIDR to use for
                                   pod IPs (default: "10.42.0.0/16")'
@@ -199,6 +204,11 @@ spec:
                                 description: 'ClusterDomain Cluster Domain (default:
                                   "cluster.local")'
                                 type: string
+                              disableCloudController:
+                                default: true
+                                description: 'DisableCloudController disables k3s
+                                  default cloud controller manager. (default: true)'
+                                type: boolean
                               disableComponents:
                                 description: DisableComponents  specifies extra commands
                                   to run before k3s setup runs
@@ -206,9 +216,9 @@ spec:
                                   type: string
                                 type: array
                               disableExternalCloudProvider:
-                                description: 'DisableExternalCloudProvider suppresses
-                                  the ''cloud-provider=external'' kubelet argument.
-                                  (default: false)'
+                                description: 'DeprecatedDisableExternalCloudProvider
+                                  suppresses the ''cloud-provider=external'' kubelet
+                                  argument. (default: false)'
                                 type: boolean
                               httpsListenPort:
                                 description: 'HTTPSListenPort HTTPS listen port (default:


### PR DESCRIPTION
Apologies for the `cabp3v1` import. I think I accidentally added that in a previous PR, so I took the occasion to clean that up.

This PR Closes https://github.com/k3s-io/cluster-api-k3s/issues/106