### PR TITLE
feat: Change from upgradeAfter to rolloutAfter in v1beta2 api upgrade

### DIFF
--- a/controlplane/api/v1beta1/conversion.go
+++ b/controlplane/api/v1beta1/conversion.go
@@ -32,7 +32,7 @@ func Convert_v1beta1_KThreesControlPlaneSpec_To_v1beta2_KThreesControlPlaneSpec(
 	if err := Convert_v1beta1_KThreesConfigSpec_To_v1beta2_KThreesConfigSpec(&in.KThreesConfigSpec, &out.KThreesConfigSpec, s); err != nil {
 		return fmt.Errorf("converting KThreesConfigSpec field from v1beta1 to v1beta2: %w", err)
 	}
-	out.UpgradeAfter = in.UpgradeAfter
+	out.RolloutAfter = in.UpgradeAfter
 	if err := Convert_v1beta1_KThreesControlPlaneMachineTemplate_To_v1beta2_KThreesControlPlaneMachineTemplate(&in.MachineTemplate, &out.MachineTemplate, s); err != nil {
 		return fmt.Errorf("converting KThreesControlPlaneMachineTemplate field from v1beta1 to v1beta2: %w", err)
 	}
@@ -49,7 +49,7 @@ func Convert_v1beta2_KThreesControlPlaneSpec_To_v1beta1_KThreesControlPlaneSpec(
 	if err := Convert_v1beta2_KThreesConfigSpec_To_v1beta1_KThreesConfigSpec(&in.KThreesConfigSpec, &out.KThreesConfigSpec, s); err != nil {
 		return fmt.Errorf("converting KThreesConfigSpec field from v1beta2 to v1beta1: %w", err)
 	}
-	out.UpgradeAfter = in.UpgradeAfter
+	out.UpgradeAfter = in.RolloutAfter
 	out.NodeDrainTimeout = in.MachineTemplate.NodeDrainTimeout
 	if err := Convert_v1beta2_KThreesControlPlaneMachineTemplate_To_v1beta1_KThreesControlPlaneMachineTemplate(&in.MachineTemplate, &out.MachineTemplate, s); err != nil {
 		return fmt.Errorf("converting KThreesControlPlaneMachineTemplate field from v1beta2 to v1beta1: %w", err)

--- a/controlplane/api/v1beta1/zz_generated.conversion.go
+++ b/controlplane/api/v1beta1/zz_generated.conversion.go
@@ -221,7 +221,7 @@ func autoConvert_v1beta1_KThreesControlPlaneSpec_To_v1beta2_KThreesControlPlaneS
 	if err := Convert_v1beta1_KThreesConfigSpec_To_v1beta2_KThreesConfigSpec(&in.KThreesConfigSpec, &out.KThreesConfigSpec, s); err != nil {
 		return err
 	}
-	out.UpgradeAfter = (*v1.Time)(unsafe.Pointer(in.UpgradeAfter))
+	// WARNING: in.UpgradeAfter requires manual conversion: does not exist in peer-type
 	// WARNING: in.NodeDrainTimeout requires manual conversion: does not exist in peer-type
 	if err := Convert_v1beta1_KThreesControlPlaneMachineTemplate_To_v1beta2_KThreesControlPlaneMachineTemplate(&in.MachineTemplate, &out.MachineTemplate, s); err != nil {
 		return err
@@ -236,7 +236,7 @@ func autoConvert_v1beta2_KThreesControlPlaneSpec_To_v1beta1_KThreesControlPlaneS
 	if err := Convert_v1beta2_KThreesConfigSpec_To_v1beta1_KThreesConfigSpec(&in.KThreesConfigSpec, &out.KThreesConfigSpec, s); err != nil {
 		return err
 	}
-	out.UpgradeAfter = (*v1.Time)(unsafe.Pointer(in.UpgradeAfter))
+	// WARNING: in.RolloutAfter requires manual conversion: does not exist in peer-type
 	if err := Convert_v1beta2_KThreesControlPlaneMachineTemplate_To_v1beta1_KThreesControlPlaneMachineTemplate(&in.MachineTemplate, &out.MachineTemplate, s); err != nil {
 		return err
 	}

--- a/controlplane/api/v1beta2/kthreescontrolplane_types.go
+++ b/controlplane/api/v1beta2/kthreescontrolplane_types.go
@@ -71,11 +71,11 @@ type KThreesControlPlaneSpec struct {
 	// +optional
 	KThreesConfigSpec bootstrapv1beta2.KThreesConfigSpec `json:"kthreesConfigSpec,omitempty"`
 
-	// UpgradeAfter is a field to indicate an upgrade should be performed
+	// RolloutAfter is a field to indicate a rollout should be performed
 	// after the specified time even if no changes have been made to the
 	// KThreesControlPlane
 	// +optional
-	UpgradeAfter *metav1.Time `json:"upgradeAfter,omitempty"`
+	RolloutAfter *metav1.Time `json:"rolloutAfter,omitempty"`
 
 	// MachineTemplate contains information about how machines should be shaped
 	// when creating or updating a control plane.

--- a/controlplane/api/v1beta2/kthreescontrolplanetemplate_types.go
+++ b/controlplane/api/v1beta2/kthreescontrolplanetemplate_types.go
@@ -45,7 +45,7 @@ type KThreesControlPlaneTemplateResourceSpec struct {
 	// after the specified time even if no changes have been made to the
 	// KThreesControlPlane
 	// +optional
-	UpgradeAfter *metav1.Time `json:"upgradeAfter,omitempty"`
+	RolloutAfter *metav1.Time `json:"upgradeAfter,omitempty"`
 
 	// MachineTemplate contains information about how machines should be shaped
 	// when creating or updating a control plane.

--- a/controlplane/api/v1beta2/kthreescontrolplanetemplate_types.go
+++ b/controlplane/api/v1beta2/kthreescontrolplanetemplate_types.go
@@ -41,11 +41,11 @@ type KThreesControlPlaneTemplateResourceSpec struct {
 	// +optional
 	KThreesConfigSpec bootstrapv1beta2.KThreesConfigSpec `json:"kthreesConfigSpec,omitempty"`
 
-	// UpgradeAfter is a field to indicate an upgrade should be performed
+	// RolloutAfter is a field to indicate an rollout should be performed
 	// after the specified time even if no changes have been made to the
 	// KThreesControlPlane
 	// +optional
-	RolloutAfter *metav1.Time `json:"upgradeAfter,omitempty"`
+	RolloutAfter *metav1.Time `json:"rolloutAfter,omitempty"`
 
 	// MachineTemplate contains information about how machines should be shaped
 	// when creating or updating a control plane.

--- a/controlplane/api/v1beta2/zz_generated.deepcopy.go
+++ b/controlplane/api/v1beta2/zz_generated.deepcopy.go
@@ -116,8 +116,8 @@ func (in *KThreesControlPlaneSpec) DeepCopyInto(out *KThreesControlPlaneSpec) {
 		**out = **in
 	}
 	in.KThreesConfigSpec.DeepCopyInto(&out.KThreesConfigSpec)
-	if in.UpgradeAfter != nil {
-		in, out := &in.UpgradeAfter, &out.UpgradeAfter
+	if in.RolloutAfter != nil {
+		in, out := &in.RolloutAfter, &out.RolloutAfter
 		*out = (*in).DeepCopy()
 	}
 	in.MachineTemplate.DeepCopyInto(&out.MachineTemplate)
@@ -249,8 +249,8 @@ func (in *KThreesControlPlaneTemplateResource) DeepCopy() *KThreesControlPlaneTe
 func (in *KThreesControlPlaneTemplateResourceSpec) DeepCopyInto(out *KThreesControlPlaneTemplateResourceSpec) {
 	*out = *in
 	in.KThreesConfigSpec.DeepCopyInto(&out.KThreesConfigSpec)
-	if in.UpgradeAfter != nil {
-		in, out := &in.UpgradeAfter, &out.UpgradeAfter
+	if in.RolloutAfter != nil {
+		in, out := &in.RolloutAfter, &out.RolloutAfter
 		*out = (*in).DeepCopy()
 	}
 	in.MachineTemplate.DeepCopyInto(&out.MachineTemplate)

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_kthreescontrolplanes.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_kthreescontrolplanes.yaml
@@ -957,9 +957,9 @@ spec:
                   This is a pointer to distinguish between explicit zero and not specified.
                 format: int32
                 type: integer
-              upgradeAfter:
+              rolloutAfter:
                 description: |-
-                  UpgradeAfter is a field to indicate an upgrade should be performed
+                  RolloutAfter is a field to indicate a rollout should be performed
                   after the specified time even if no changes have been made to the
                   KThreesControlPlane
                 format: date-time

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_kthreescontrolplanetemplates.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_kthreescontrolplanetemplates.yaml
@@ -393,9 +393,9 @@ spec:
                               If not set, a retry will happen immediately.
                             type: string
                         type: object
-                      upgradeAfter:
+                      rolloutAfter:
                         description: |-
-                          UpgradeAfter is a field to indicate an upgrade should be performed
+                          RolloutAfter is a field to indicate an rollout should be performed
                           after the specified time even if no changes have been made to the
                           KThreesControlPlane
                         format: date-time

--- a/pkg/k3s/control_plane.go
+++ b/pkg/k3s/control_plane.go
@@ -284,8 +284,8 @@ func (c *ControlPlane) MachinesNeedingRollout() collections.Machines {
 
 	// Return machines if they are scheduled for rollout or if with an outdated configuration.
 	return machines.AnyFilter(
-		// Machines that are scheduled for rollout (KCP.Spec.UpgradeAfter set, the UpgradeAfter deadline is expired, and the machine was created before the deadline).
-		collections.ShouldRolloutAfter(&c.reconciliationTime, c.KCP.Spec.UpgradeAfter),
+		// Machines that are scheduled for rollout (KCP.Spec.RolloutAfter set, the RolloutAfter deadline is expired, and the machine was created before the deadline).
+		collections.ShouldRolloutAfter(&c.reconciliationTime, c.KCP.Spec.RolloutAfter),
 		// Machines that do not match with KCP config.
 		collections.Not(machinefilters.MatchesKCPConfiguration(c.infraResources, c.kthreesConfigs, c.KCP)),
 	)


### PR DESCRIPTION
This PR changes v1beta2 to use rolloutAfter instead of upgradeAfter for parity with the kubeadm controlplane in cluster-api.
Addresses: https://github.com/k3s-io/cluster-api-k3s/issues/115