### PR TITLE
Add a github workflow to enable e2e for PR blocker

### DIFF
--- a/.github/workflows/e2e-pr.yaml
+++ b/.github/workflows/e2e-pr.yaml
@@ -1,0 +1,50 @@
+name: E2E tests (PR Blocker)
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  e2e-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          docker-images: false
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Build e2e image
+        run: make docker-build-e2e
+      - uses: actions/cache@v4.0.2
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-test-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-test-go-${{ hashFiles('**/go.sum') }}
+      - uses: engineerd/setup-kind@v0.5.0
+        with:
+          version: "v0.22.0"
+          skipClusterCreation: "true"
+      - name: Run E2E tests
+        run: make GINKGO_FOCUS="\\[PR-Blocking\\]" test-e2e
+      - name: Archive artifacts
+        if: always()
+        uses: actions/upload-artifact@v4.3.2
+        with:
+          name: e2e-artifacts
+          path: _artifacts
+          if-no-files-found: ignore


### PR DESCRIPTION
This PR add a PR blocker with e2e. For now, it will build the repo and verifying by creating a cluster with 1 CP and 3 worker nodes. I mainly follow [rke2 setup](https://github.com/rancher-sandbox/cluster-api-provider-rke2/blob/main/.github/workflows/e2e.yml) and a successful run could be found [here](https://github.com/nasusoba/cluster-api-k3s/actions/runs/9122826401/job/25084256460).

If we want to add other test specs as a PR Blocker, we could simply add `[PR-Blocking]` in its spec name. 

#25 