### PR TITLE
Fix a TODO for kubeconfig rotation

### DIFF
--- a/controlplane/controllers/kthreescontrolplane_controller.go
+++ b/controlplane/controllers/kthreescontrolplane_controller.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/external"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
+	"sigs.k8s.io/cluster-api/util/certs"
 	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
@@ -640,20 +641,17 @@ func (r *KThreesControlPlaneReconciler) reconcileKubeconfig(ctx context.Context,
 		return reconcile.Result{}, nil
 	}
 
-	/**
-	// TODO rotation
 	needsRotation, err := kubeconfig.NeedsClientCertRotation(configSecret, certs.ClientCertificateRenewalDuration)
 	if err != nil {
-		return err
+		return ctrl.Result{}, err
 	}
 
 	if needsRotation {
 		r.Log.Info("rotating kubeconfig secret")
 		if err := kubeconfig.RegenerateSecret(ctx, r.Client, configSecret); err != nil {
-			return fmt.Errorf("failed to regenerate kubeconfig")
+			return ctrl.Result{}, errors.Wrap(err, "failed to regenerate kubeconfig")
 		}
 	}
-	**/
 
 	return reconcile.Result{}, nil
 }

--- a/pkg/k3s/management_cluster.go
+++ b/pkg/k3s/management_cluster.go
@@ -80,7 +80,7 @@ const (
 func (m *Management) GetWorkloadCluster(ctx context.Context, clusterKey client.ObjectKey) (*Workload, error) {
 	restConfig, err := remote.RESTConfig(ctx, KThreesControlPlaneControllerName, m.Client, clusterKey)
 	if err != nil {
-		return nil, err
+		return nil, &RemoteClusterConnectionError{Name: clusterKey.String(), Err: err}
 	}
 	restConfig.Timeout = 30 * time.Second
 


### PR DESCRIPTION
* Fix a TODO for rotating kubeconfig secret if it is close to expiring
    * When created, kubeconfig secret will be effective for a year. If kubeconfig secret will expired in 180 days, it will get rotated
* Address RestConfig creation failure as `RemoteClusterConnectionError` (same as CAPI)

I have manually verified the cert could be rotated and the rotated secret could still be used to connect to the workload cluster.