### PR TITLE
Fix a bug for ClusterClass e2e template [e2e test] 

### DIFF
--- a/test/e2e/data/infrastructure-docker/clusterclass-k3s.yaml
+++ b/test/e2e/data/infrastructure-docker/clusterclass-k3s.yaml
@@ -40,7 +40,10 @@ spec:
               name: k3s-default-worker-machinetemplate
         machineHealthCheck:
             maxUnhealthy: 100%
-            # We are intentionally not setting the 'unhealthyConditions' here to test that the field is optional.
+            unhealthyConditions:
+              - type: e2e.remediation.condition
+                status: "False"
+                timeout: 20s
     machinePools:
     - class: k3s-default-worker
       template:


### PR DESCRIPTION
This PR added `unhealthyConditions` to ClusterClass template. I copied the template from CAPI main, but not realized the feature for optional `unhealthyConditions` is not yet released for CAPI core `v1.7.2` (which we used to for e2e). I have tested #124 , but that time I accidentally used a CAPI core build from main branch, so did not find this bug. 