### PR TITLE
fix: Set requeue time for etcd proxy [etcd proxy][v0.2.0]

### DIFF
--- a/controlplane/controllers/const.go
+++ b/controlplane/controllers/const.go
@@ -31,5 +31,9 @@ const (
 	// dependent certificates have been created.
 	dependentCertRequeueAfter = 30 * time.Second
 
+	// etcdRemovalRequeueAfter is how long to wait before checking again to see if
+	// etcd member is successfully removed.
+	etcdRemovalRequeueAfter = 30 * time.Second
+
 	k3sHookName = "k3s"
 )

--- a/controlplane/controllers/kthreescontrolplane_controller.go
+++ b/controlplane/controllers/kthreescontrolplane_controller.go
@@ -97,7 +97,7 @@ func (r *KThreesControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.
 	}
 	if cluster == nil {
 		logger.Info("Cluster Controller has not yet set OwnerRef")
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{}, nil
 	}
 	logger = logger.WithValues("cluster", cluster.Name)
 

--- a/controlplane/controllers/machine_controller.go
+++ b/controlplane/controllers/machine_controller.go
@@ -130,7 +130,7 @@ func (r *MachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			}
 			if !etcdRemoved {
 				logger.Info("wait k3s embedded etcd controller to remove etcd")
-				return ctrl.Result{Requeue: true}, err
+				return ctrl.Result{RequeueAfter: etcdRemovalRequeueAfter}, nil
 			}
 
 			nodeName := ""


### PR DESCRIPTION
We did not set a requeue time for etcd proxy machine controller, so the request will be requeued immediately. This triggered lots of requeue, which results the requeue time hits the rate limter upper limit (~`16.67m` which is too long for deletion). As the time between CAPI initialize the etcd removal request to the etcd member is actually removed, it might take ~ 1min. Add a requeue time of 30s so the controller will wait for a while until it pinging the api server again.