### PR TITLE
Add system-default-registry setting

### DIFF
--- a/bootstrap/api/v1beta1/conversion.go
+++ b/bootstrap/api/v1beta1/conversion.go
@@ -42,6 +42,7 @@ func (c *KThreesConfig) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	dst.Spec.ServerConfig.CloudProviderName = restored.Spec.ServerConfig.CloudProviderName
 	dst.Spec.ServerConfig.DeprecatedDisableExternalCloudProvider = restored.Spec.ServerConfig.DeprecatedDisableExternalCloudProvider
 	dst.Spec.ServerConfig.DisableCloudController = restored.Spec.ServerConfig.DisableCloudController
+	dst.Spec.ServerConfig.SystemDefaultRegistry = restored.Spec.ServerConfig.SystemDefaultRegistry
 	return nil
 }
 
@@ -94,6 +95,7 @@ func (r *KThreesConfigTemplate) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	dst.Spec.Template.Spec.ServerConfig.CloudProviderName = restored.Spec.Template.Spec.ServerConfig.CloudProviderName
 	dst.Spec.Template.Spec.ServerConfig.DeprecatedDisableExternalCloudProvider = restored.Spec.Template.Spec.ServerConfig.DeprecatedDisableExternalCloudProvider
 	dst.Spec.Template.Spec.ServerConfig.DisableCloudController = restored.Spec.Template.Spec.ServerConfig.DisableCloudController
+	dst.Spec.Template.Spec.ServerConfig.SystemDefaultRegistry = restored.Spec.Template.Spec.ServerConfig.SystemDefaultRegistry
 	return nil
 }
 

--- a/bootstrap/api/v1beta1/zz_generated.conversion.go
+++ b/bootstrap/api/v1beta1/zz_generated.conversion.go
@@ -550,6 +550,7 @@ func autoConvert_v1beta2_KThreesServerConfig_To_v1beta1_KThreesServerConfig(in *
 	// WARNING: in.DeprecatedDisableExternalCloudProvider requires manual conversion: does not exist in peer-type
 	// WARNING: in.DisableCloudController requires manual conversion: does not exist in peer-type
 	// WARNING: in.CloudProviderName requires manual conversion: does not exist in peer-type
+	// WARNING: in.SystemDefaultRegistry requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/bootstrap/api/v1beta2/kthreesconfig_types.go
+++ b/bootstrap/api/v1beta2/kthreesconfig_types.go
@@ -120,6 +120,10 @@ type KThreesServerConfig struct {
 	// CloudProviderName defines the --cloud-provider= kubelet extra arg. (default: "external")
 	// +optional
 	CloudProviderName *string `json:"cloudProviderName,omitempty"`
+
+	// SystemDefaultRegistry defines private registry to be used for all system images
+	// +optional
+	SystemDefaultRegistry string `json:"systemDefaultRegistry,omitempty"`
 }
 
 type KThreesAgentConfig struct {

--- a/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_kthreesconfigs.yaml
+++ b/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_kthreesconfigs.yaml
@@ -496,6 +496,10 @@ spec:
                     description: 'ServiceCidr Network CIDR to use for services IPs
                       (default: "10.43.0.0/16")'
                     type: string
+                  systemDefaultRegistry:
+                    description: SystemDefaultRegistry defines private registry to
+                      be used for all system images
+                    type: string
                   tlsSan:
                     description: TLSSan Add additional hostname or IP as a Subject
                       Alternative Name in the TLS cert

--- a/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_kthreesconfigtemplates.yaml
+++ b/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_kthreesconfigtemplates.yaml
@@ -458,6 +458,10 @@ spec:
                             description: 'ServiceCidr Network CIDR to use for services
                               IPs (default: "10.43.0.0/16")'
                             type: string
+                          systemDefaultRegistry:
+                            description: SystemDefaultRegistry defines private registry
+                              to be used for all system images
+                            type: string
                           tlsSan:
                             description: TLSSan Add additional hostname or IP as a
                               Subject Alternative Name in the TLS cert

--- a/controlplane/api/v1beta1/conversion.go
+++ b/controlplane/api/v1beta1/conversion.go
@@ -93,6 +93,7 @@ func (in *KThreesControlPlane) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	dst.Spec.KThreesConfigSpec.ServerConfig.CloudProviderName = restored.Spec.KThreesConfigSpec.ServerConfig.CloudProviderName
 	dst.Spec.KThreesConfigSpec.ServerConfig.DeprecatedDisableExternalCloudProvider = restored.Spec.KThreesConfigSpec.ServerConfig.DeprecatedDisableExternalCloudProvider
 	dst.Spec.KThreesConfigSpec.ServerConfig.DisableCloudController = restored.Spec.KThreesConfigSpec.ServerConfig.DisableCloudController
+	dst.Spec.KThreesConfigSpec.ServerConfig.SystemDefaultRegistry = restored.Spec.KThreesConfigSpec.ServerConfig.SystemDefaultRegistry
 	dst.Spec.MachineTemplate.NodeVolumeDetachTimeout = restored.Spec.MachineTemplate.NodeVolumeDetachTimeout
 	dst.Spec.MachineTemplate.NodeDeletionTimeout = restored.Spec.MachineTemplate.NodeDeletionTimeout
 	dst.Status.Version = restored.Status.Version

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_kthreescontrolplanes.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_kthreescontrolplanes.yaml
@@ -804,6 +804,10 @@ spec:
                         description: 'ServiceCidr Network CIDR to use for services
                           IPs (default: "10.43.0.0/16")'
                         type: string
+                      systemDefaultRegistry:
+                        description: SystemDefaultRegistry defines private registry
+                          to be used for all system images
+                        type: string
                       tlsSan:
                         description: TLSSan Add additional hostname or IP as a Subject
                           Alternative Name in the TLS cert

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_kthreescontrolplanetemplates.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_kthreescontrolplanetemplates.yaml
@@ -244,6 +244,10 @@ spec:
                                 description: 'ServiceCidr Network CIDR to use for
                                   services IPs (default: "10.43.0.0/16")'
                                 type: string
+                              systemDefaultRegistry:
+                                description: SystemDefaultRegistry defines private
+                                  registry to be used for all system images
+                                type: string
                               tlsSan:
                                 description: TLSSan Add additional hostname or IP
                                   as a Subject Alternative Name in the TLS cert

--- a/pkg/k3s/config.go
+++ b/pkg/k3s/config.go
@@ -25,6 +25,7 @@ type K3sServerConfig struct {
 	ClusterDomain             string   `json:"cluster-domain,omitempty"`
 	DisableComponents         []string `json:"disable,omitempty"`
 	ClusterInit               bool     `json:"cluster-init,omitempty"`
+	SystemDefaultRegistry     string   `json:"system-default-registry,omitempty"`
 	K3sAgentConfig            `json:",inline"`
 }
 
@@ -57,6 +58,7 @@ func GenerateInitControlPlaneConfig(controlPlaneEndpoint string, token string, s
 		ClusterDNS:                serverConfig.ClusterDNS,
 		ClusterDomain:             serverConfig.ClusterDomain,
 		DisableComponents:         serverConfig.DisableComponents,
+		SystemDefaultRegistry:     serverConfig.SystemDefaultRegistry,
 	}
 
 	k3sServerConfig.K3sAgentConfig = K3sAgentConfig{
@@ -89,6 +91,7 @@ func GenerateJoinControlPlaneConfig(serverURL string, token string, controlplane
 		ClusterDNS:                serverConfig.ClusterDNS,
 		ClusterDomain:             serverConfig.ClusterDomain,
 		DisableComponents:         serverConfig.DisableComponents,
+		SystemDefaultRegistry:     serverConfig.SystemDefaultRegistry,
 	}
 
 	k3sServerConfig.K3sAgentConfig = K3sAgentConfig{


### PR DESCRIPTION
Add `systemDefaultRegistry`, it will allow defining private registry to be used for all system images for k3s