### PR TITLE
fix: metadata add release series

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,9 @@
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
-- major: 0
-  minor: 1
-  contract: v1beta1
+  - major: 0
+    minor: 1
+    contract: v1beta1
+  - major: 0
+    minor: 2
+    contract: v1beta1


### PR DESCRIPTION
Add the missing release series to the metadata so that the v0.2.0 release is installable from clusterctl.