### PR TITLE
feature/support-proxy-url-definition-via-kubeconfig

### DIFF
--- a/controlplane/controllers/kthreescontrolplane_controller.go
+++ b/controlplane/controllers/kthreescontrolplane_controller.go
@@ -648,6 +648,7 @@ func (r *KThreesControlPlaneReconciler) reconcileKubeconfig(ctx context.Context,
 			clusterName,
 			endpoint.String(),
 			controllerOwnerRef,
+			nil,
 		)
 		if errors.Is(createErr, kubeconfig.ErrDependentCertificateNotFound) {
 			return ctrl.Result{RequeueAfter: dependentCertRequeueAfter}, nil


### PR DESCRIPTION
The implementations out for review are used to support proxy URL definition via kubeconfig.