### PR TITLE
chore: bump metadata for v0.4.x series

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -9,4 +9,7 @@ releaseSeries:
     contract: v1beta1
   - major: 0
     minor: 3
-    contract: v1beta2
+    contract: v1beta1
+  - major: 0
+    minor: 4
+    contract: v1beta1


### PR DESCRIPTION
This adds a metadata entry for v0.4

Note: the provider still adheres to the CAPI v1beta1 contract. We need to do a API version bump to move the provider to v1beta2