### PR TITLE
fix: increase e2e workflow timeout

### DIFF
--- a/.github/workflows/e2e-full.yaml
+++ b/.github/workflows/e2e-full.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - name: "Clear out GitHub Runner"
         run: |


### PR DESCRIPTION
Increase the e2e workflow timeout to 2 hours.