### PR TITLE
Fix control-plane node detection for modern K3s

### DIFF
--- a/pkg/k3s/workload_cluster.go
+++ b/pkg/k3s/workload_cluster.go
@@ -33,9 +33,13 @@ import (
 )
 
 const (
-	kubeProxyKey              = "kube-proxy"
-	labelNodeRoleControlPlane = "node-role.kubernetes.io/master"
-	k3sServingSecretKey       = "k3s-serving"
+	kubeProxyKey = "kube-proxy"
+	// Modern K3s sets only the canonical control-plane label; older K3s
+	// (and clusters bootstrapped under it) still use the deprecated master
+	// label. Both are matched so old and new clusters work.
+	labelNodeRoleControlPlane           = "node-role.kubernetes.io/control-plane"
+	labelNodeRoleControlPlaneDeprecated = "node-role.kubernetes.io/master"
+	k3sServingSecretKey                 = "k3s-serving"
 )
 
 var ErrControlPlaneMinNodes = errors.New("cluster has fewer than 2 control plane nodes; removing an etcd member is not supported")
@@ -78,15 +82,29 @@ type ClusterStatus struct {
 	HasK3sServingSecret bool
 }
 
+// getControlPlaneNodes lists workload-cluster nodes matching either the modern
+// or deprecated control-plane role label. Two filtered List calls are needed
+// because Kubernetes label selectors cannot OR across different keys; results
+// are deduplicated because a node may transiently carry both labels during an
+// upgrade.
 func (w *Workload) getControlPlaneNodes(ctx context.Context) (*corev1.NodeList, error) {
-	nodes := &corev1.NodeList{}
-	labels := map[string]string{
-		labelNodeRoleControlPlane: "true",
+	out := &corev1.NodeList{}
+	seen := sets.New[string]()
+	for _, key := range []string{labelNodeRoleControlPlane, labelNodeRoleControlPlaneDeprecated} {
+		nodes := &corev1.NodeList{}
+		if err := w.Client.List(ctx, nodes, ctrlclient.MatchingLabels{key: "true"}); err != nil {
+			return nil, err
+		}
+		for i := range nodes.Items {
+			n := nodes.Items[i]
+			if seen.Has(n.Name) {
+				continue
+			}
+			seen.Insert(n.Name)
+			out.Items = append(out.Items, n)
+		}
 	}
-	if err := w.Client.List(ctx, nodes, ctrlclient.MatchingLabels(labels)); err != nil {
-		return nil, err
-	}
-	return nodes, nil
+	return out, nil
 }
 
 // ClusterStatus returns the status of the cluster.

--- a/pkg/k3s/workload_cluster_test.go
+++ b/pkg/k3s/workload_cluster_test.go
@@ -11,70 +11,137 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+// Pinned to literal label keys (not the production constants) so the test
+// asserts the K3s wire contract and survives constant renames.
+const (
+	testLabelNodeRoleControlPlane           = "node-role.kubernetes.io/control-plane"
+	testLabelNodeRoleControlPlaneDeprecated = "node-role.kubernetes.io/master"
+)
+
+func makeNode(name string, ready bool, labels map[string]string) *corev1.Node {
+	status := corev1.ConditionFalse
+	if ready {
+		status = corev1.ConditionTrue
+	}
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{
+				Type:   corev1.NodeReady,
+				Status: status,
+			}},
+		},
+	}
+}
+
 func TestClusterStatus(t *testing.T) {
-	node1 := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "node1",
-			Labels: map[string]string{
-				labelNodeRoleControlPlane: "true",
-			},
-		},
-		Status: corev1.NodeStatus{
-			Conditions: []corev1.NodeCondition{{
-				Type:   corev1.NodeReady,
-				Status: corev1.ConditionTrue,
-			}},
-		},
-	}
-	node2 := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "node2",
-			Labels: map[string]string{
-				labelNodeRoleControlPlane: "true",
-			},
-		},
-		Status: corev1.NodeStatus{
-			Conditions: []corev1.NodeCondition{{
-				Type:   corev1.NodeReady,
-				Status: corev1.ConditionFalse,
-			}},
-		},
-	}
 	servingSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      k3sServingSecretKey,
 			Namespace: metav1.NamespaceSystem,
 		},
 	}
+
 	tests := []struct {
-		name            string
-		objs            []client.Object
-		expectErr       bool
-		expectHasSecret bool
+		name             string
+		nodes            []client.Object
+		includeSecret    bool
+		expectNodes      int32
+		expectReadyNodes int32
+		expectHasSecret  bool
 	}{
 		{
-			name:            "returns cluster status",
-			objs:            []client.Object{node1, node2},
-			expectHasSecret: false,
+			name: "modern K3s: nodes labeled with control-plane only are counted",
+			nodes: []client.Object{
+				makeNode("cp-modern-1", true, map[string]string{testLabelNodeRoleControlPlane: "true"}),
+				makeNode("cp-modern-2", false, map[string]string{testLabelNodeRoleControlPlane: "true"}),
+			},
+			expectNodes:      2,
+			expectReadyNodes: 1,
 		},
 		{
-			name:            "returns cluster status with k3s-serving secret",
-			objs:            []client.Object{node1, node2, servingSecret},
-			expectHasSecret: true,
+			name: "legacy K3s: nodes labeled with the deprecated master label only are counted",
+			nodes: []client.Object{
+				makeNode("cp-legacy-1", true, map[string]string{testLabelNodeRoleControlPlaneDeprecated: "true"}),
+				makeNode("cp-legacy-2", false, map[string]string{testLabelNodeRoleControlPlaneDeprecated: "true"}),
+			},
+			expectNodes:      2,
+			expectReadyNodes: 1,
+		},
+		{
+			name: "transitional: a node carrying both labels is counted exactly once",
+			nodes: []client.Object{
+				makeNode("cp-both", true, map[string]string{
+					testLabelNodeRoleControlPlane:           "true",
+					testLabelNodeRoleControlPlaneDeprecated: "true",
+				}),
+			},
+			expectNodes:      1,
+			expectReadyNodes: 1,
+		},
+		{
+			name: "mixed cluster: modern + legacy + dual-labelled nodes are all counted exactly once",
+			nodes: []client.Object{
+				makeNode("cp-modern", true, map[string]string{testLabelNodeRoleControlPlane: "true"}),
+				makeNode("cp-legacy", false, map[string]string{testLabelNodeRoleControlPlaneDeprecated: "true"}),
+				makeNode("cp-both", true, map[string]string{
+					testLabelNodeRoleControlPlane:           "true",
+					testLabelNodeRoleControlPlaneDeprecated: "true",
+				}),
+			},
+			expectNodes:      3,
+			expectReadyNodes: 2,
+		},
+		{
+			name: "worker nodes (no control-plane role label) are excluded",
+			nodes: []client.Object{
+				makeNode("cp", true, map[string]string{testLabelNodeRoleControlPlane: "true"}),
+				makeNode("worker-bare", true, nil),
+				makeNode("worker-other-label", true, map[string]string{"example.com/role": "true"}),
+			},
+			expectNodes:      1,
+			expectReadyNodes: 1,
+		},
+		{
+			name: "k3s-serving secret detection still works with modern labels",
+			nodes: []client.Object{
+				makeNode("cp", true, map[string]string{testLabelNodeRoleControlPlane: "true"}),
+			},
+			includeSecret:    true,
+			expectNodes:      1,
+			expectReadyNodes: 1,
+			expectHasSecret:  true,
+		},
+		{
+			name: "k3s-serving secret detection still works with legacy labels",
+			nodes: []client.Object{
+				makeNode("cp", true, map[string]string{testLabelNodeRoleControlPlaneDeprecated: "true"}),
+			},
+			includeSecret:    true,
+			expectNodes:      1,
+			expectReadyNodes: 1,
+			expectHasSecret:  true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			fakeClient := fake.NewClientBuilder().WithObjects(tt.objs...).Build()
+			objs := append([]client.Object{}, tt.nodes...)
+			if tt.includeSecret {
+				objs = append(objs, servingSecret)
+			}
+			fakeClient := fake.NewClientBuilder().WithObjects(objs...).Build()
 			w := &Workload{
 				Client: fakeClient,
 			}
 			status, err := w.ClusterStatus(context.TODO())
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(status.Nodes).To(BeEquivalentTo(2))
-			g.Expect(status.ReadyNodes).To(BeEquivalentTo(1))
+			g.Expect(status.Nodes).To(BeEquivalentTo(tt.expectNodes))
+			g.Expect(status.ReadyNodes).To(BeEquivalentTo(tt.expectReadyNodes))
 			g.Expect(status.HasK3sServingSecret).To(Equal(tt.expectHasSecret))
 		})
 	}


### PR DESCRIPTION
## Problem

Modern K3s (1.34+) only sets `node-role.kubernetes.io/control-plane=true` on
control plane nodes. The deprecated `node-role.kubernetes.io/master` label is
no longer applied. CACP3's `getControlPlaneNodes()` only matches the deprecated
label, so on modern K3s clusters it returns zero nodes — breaking
`ClusterStatus`, agent/etcd condition updates, etcd member management, and
leadership forwarding.

A K3s-side workaround (declaring the label via `agentConfig.nodeLabels`) is
not viable: kubelet on Kubernetes 1.24+ rejects `kubernetes.io/*` labels passed
through `--node-labels`.

## Fix

`getControlPlaneNodes()` now matches **either** label key. Since Kubernetes
label selectors cannot OR across different keys, this is implemented as two
filtered `List` calls (one per label) with name-based deduplication. Dedup
matters because a node can transiently carry both labels during an in-place
upgrade.

Older K3s clusters still using only the master label continue to work
unchanged.

## Tests

`TestClusterStatus` is now table-driven and covers:
- modern-only label
- legacy-only label
- transitional (both labels on one node)
- mixed cluster (some nodes legacy, some modern)
- worker-node exclusion
- serving-secret detection on both label paths